### PR TITLE
Updated nginx.conf file as per requirement

### DIFF
--- a/templates/microApp/nginx.conf
+++ b/templates/microApp/nginx.conf
@@ -1,0 +1,92 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log  notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;  ## Default: 1024
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0; #The zero value disables keep-alive client connections.
+    keepalive_timeout  65;
+
+    # Compression
+    # Enable Gzip compressed.
+    gzip on;
+
+    # Compression level (1-9).
+    # 5 is a perfect compromise between size and cpu usage, offering about
+    # 75% reduction for most ascii files (almost identical to level 9).
+    gzip_comp_level    5;
+
+    # Don't compress anything that's already small and unlikely to shrink much
+    # if at all (the default is 20 bytes, which is bad as that usually leads to
+    # larger files after gzipping).
+    gzip_min_length    256;
+
+    # Compress data even for clients that are connecting to us via proxies,
+    # identified by the "Via" header (required for CloudFront).
+    gzip_proxied       any;
+
+    # Tell proxies to cache both the gzipped and regular version of a resource
+    # whenever the client's Accept-Encoding capabilities header varies;
+    # Avoids the issue where a non-gzip capable client (which is extremely rare
+    # today) would display gibberish if their proxy gave them the gzipped version.
+    gzip_vary          on;
+
+    # This should be turned on if you are going to have pre-compressed copies (.gz) of 
+    # static files available. If not it should be left off as it will cause extra I/O 
+    # for the check. It is best if you enable this in a location{} block for 
+    # a specific directory, or on an individual server{} level. 
+    # gzip_static on; 
+
+    map $sent_http_content_type $expires {
+        default                    off;
+        text/html                  epoch;
+        application/json           1d;
+        text/css                   365d;
+        application/javascript     365d;
+        ~image/                    365d;
+        ~font/                     365d;
+    }
+
+    server {
+        listen  80;
+        listen  [::]:80;  
+        # change the domain name
+        server_name  domain.name;
+        expires $expires;
+
+        #access_log  logs/host.access.log  main;
+
+        location / {
+            # change the root location 
+            root   /some/location/html;
+            index  index.html index.htm;
+            try_files $uri $uri.html $uri/ 404;
+
+            if ($request_uri ~ /index(.html)?$) {
+                rewrite ^(.*/)index(.html)?$ $1 permanent;
+            }
+            if ($request_uri ~ \.html$) {
+                rewrite ^(.*)\.html$ $1 permanent;
+            }
+        }
+
+        error_page  404              /404.html;
+        error_page  500 502 503 504  /50x.html;
+    }
+}

--- a/templates/ssg/nginx.conf
+++ b/templates/ssg/nginx.conf
@@ -1,16 +1,92 @@
-events {}
+user  nginx;
+worker_processes  auto;
 
+error_log  /var/log/nginx/error.log  notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;  ## Default: 1024
+}
 
 http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
 
-  server {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
 
-    include mime.types;
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    #tcp_nopush     on;
 
-    listen 80;
-    server_name localhost;
+    #keepalive_timeout  0; #The zero value disables keep-alive client connections.
+    keepalive_timeout  65;
 
-    root /app;
+    # Compression
+    # Enable Gzip compressed.
+    gzip on;
 
-  }
+    # Compression level (1-9).
+    # 5 is a perfect compromise between size and cpu usage, offering about
+    # 75% reduction for most ascii files (almost identical to level 9).
+    gzip_comp_level    5;
+
+    # Don't compress anything that's already small and unlikely to shrink much
+    # if at all (the default is 20 bytes, which is bad as that usually leads to
+    # larger files after gzipping).
+    gzip_min_length    256;
+
+    # Compress data even for clients that are connecting to us via proxies,
+    # identified by the "Via" header (required for CloudFront).
+    gzip_proxied       any;
+
+    # Tell proxies to cache both the gzipped and regular version of a resource
+    # whenever the client's Accept-Encoding capabilities header varies;
+    # Avoids the issue where a non-gzip capable client (which is extremely rare
+    # today) would display gibberish if their proxy gave them the gzipped version.
+    gzip_vary          on;
+
+    # This should be turned on if you are going to have pre-compressed copies (.gz) of 
+    # static files available. If not it should be left off as it will cause extra I/O 
+    # for the check. It is best if you enable this in a location{} block for 
+    # a specific directory, or on an individual server{} level. 
+    # gzip_static on; 
+
+    map $sent_http_content_type $expires {
+        default                    off;
+        text/html                  epoch;
+        application/json           1d;
+        text/css                   365d;
+        application/javascript     365d;
+        ~image/                    365d;
+        ~font/                     365d;
+    }
+
+    server {
+        listen  80;
+        listen  [::]:80;  
+        # change the domain name
+        server_name  domain.name;
+        expires $expires;
+
+        #access_log  logs/host.access.log  main;
+
+        location / {
+            # change the root location 
+            root   /some/location/html;
+            index  index.html index.htm;
+            try_files $uri $uri.html $uri/ 404;
+
+            if ($request_uri ~ /index(.html)?$) {
+                rewrite ^(.*/)index(.html)?$ $1 permanent;
+            }
+            if ($request_uri ~ \.html$) {
+                rewrite ^(.*)\.html$ $1 permanent;
+            }
+        }
+
+        error_page  404              /404.html;
+        error_page  500 502 503 504  /50x.html;
+    }
 }


### PR DESCRIPTION
- [x] Define shorter TTL like 1 hour on page level/manifest.json
- [x] Improve config to support one year TTL on static build assets.
  - Cache expiry is now based on the mime type, thus images, fonts, css and js files have 365d expiry. 
  - JSON files have 1d expiry while html files do not have cache enabled.
- [x] Improve to support error redirection
  - 404 errors will be redirected to 404.html file in the root app directory where index.html lives
  - Any other server error will be directed to 50x.html file again in the root app directory where index.html lives.

closes #58 