### PR TITLE
fixing files property under root pacakge.json to include all file when publish as npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "debug": "node index.js"
   },
   "files": [
-    "*"
+    "*",
+    "*/**/*"
   ],
   "bugs": {
     "url": "https://github.com/pagesource/universal-react-v2/issues"


### PR DESCRIPTION
fixing files property under root pacakge.json to include all file when publish as npm module